### PR TITLE
Using Transaction.hashForSignature that uses BCC signature algorithm

### DIFF
--- a/core/src/main/java/org/bitcoincashj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoincashj/core/Transaction.java
@@ -904,8 +904,9 @@ public class Transaction extends ChildMessage {
     public TransactionSignature calculateSignature(int inputIndex, ECKey key,
                                                                 byte[] redeemScript,
                                                                 SigHash hashType, boolean anyoneCanPay) {
-        Sha256Hash hash = hashForSignature(inputIndex, redeemScript, hashType, anyoneCanPay);
-        return new TransactionSignature(key.sign(hash), hashType, anyoneCanPay);
+        TransactionInput input = inputs.get(inputIndex);
+        Sha256Hash hash = hashForSignature(inputIndex, new Script(redeemScript), hashType, anyoneCanPay, input.getValue().value);
+        return new TransactionSignature(key.sign(hash), hashType, anyoneCanPay, true);
     }
 
     /**

--- a/core/src/main/java/org/bitcoincashj/crypto/TransactionSignature.java
+++ b/core/src/main/java/org/bitcoincashj/crypto/TransactionSignature.java
@@ -179,7 +179,7 @@ public class TransactionSignature extends ECKey.ECDSASignature {
      * @param requireCanonicalEncoding if the encoding of the signature must
      * be canonical.
      * @throws RuntimeException if the signature is invalid or unparseable in some way.
-     * @deprecated use {@link #decodeFromBitcoin(byte[], boolean, boolean} instead}.
+     * @deprecated use {@link #decodeFromBitcoin(byte[], boolean, boolean)} instead}.
      */
     @Deprecated
     public static TransactionSignature decodeFromBitcoin(byte[] bytes,

--- a/core/src/main/java/org/bitcoincashj/script/Script.java
+++ b/core/src/main/java/org/bitcoincashj/script/Script.java
@@ -1451,7 +1451,7 @@ public class Script {
                 verifyFlags.contains(VerifyFlag.LOW_S));
 
             // TODO: Should check hash type is known
-            Sha256Hash hash = txContainingThis.hashForSignature(index, connectedScript, (byte) sig.sighashFlags);
+            Sha256Hash hash = txContainingThis.hashForSignature(index, new Script(connectedScript), sig.sighashFlags);
             sigValid = ECKey.verify(hash.getBytes(), sig, pubKey);
         } catch (Exception e1) {
             // There is (at least) one exception that could be hit here (EOFException, if the sig is too short)
@@ -1525,7 +1525,7 @@ public class Script {
             // more expensive than hashing, its not a big deal.
             try {
                 TransactionSignature sig = TransactionSignature.decodeFromBitcoin(sigs.getFirst(), requireCanonical);
-                Sha256Hash hash = txContainingThis.hashForSignature(index, connectedScript, (byte) sig.sighashFlags);
+                Sha256Hash hash = txContainingThis.hashForSignature(index, new Script(connectedScript), sig.sighashFlags);
                 if (ECKey.verify(hash.getBytes(), sig, pubKey))
                     sigs.pollFirst();
             } catch (Exception e) {


### PR DESCRIPTION
I did changes that permit to call the `Transaction.hashForSignature` method that uses BCC signature algorithm. So now, when you use a `Wallet` object with its `sendCoins` methods, you really build a BCC transaction.

I did tests in `regtest` mode, and my transactions were well accepted by a Bitcoin ABC full-node.