### PR TITLE
Magic numbers and DNS seeds for Bitcoin Cash

### DIFF
--- a/core/src/main/java/org/bitcoincashj/params/MainNetParams.java
+++ b/core/src/main/java/org/bitcoincashj/params/MainNetParams.java
@@ -71,13 +71,11 @@ public class MainNetParams extends AbstractBitcoinNetParams {
         checkpoints.put(200000, Sha256Hash.wrap("000000000000034a7dedef4a161fa058a2d67a173a90155f3a2fe6fc132e0ebf"));
 
         dnsSeeds = new String[] {
-                "seed.bitcoin.sipa.be",         // Pieter Wuille
-                "dnsseed.bluematt.me",          // Matt Corallo
-                "dnsseed.bitcoin.dashjr.org",   // Luke Dashjr
-                "seed.bitcoinstats.com",        // Chris Decker
-                "seed.bitnodes.io",             // Addy Yeow
-                "bitseed.xf2.org",              // Jeff Garzik
-                "seed.bitcoin.jonasschnelli.ch" // Jonas Schnelli
+                "seed.bitcoinabc.org",
+                "seed-abc.bitcoinforks.org",
+                "seed.bitprim.org",
+                "seed.deadalnix.me",
+                "seeder.criptolayer.net"
         };
         httpSeeds = new HttpDiscovery.Details[] {
                 // Andreas Schildbach

--- a/core/src/main/java/org/bitcoincashj/params/MainNetParams.java
+++ b/core/src/main/java/org/bitcoincashj/params/MainNetParams.java
@@ -42,7 +42,7 @@ public class MainNetParams extends AbstractBitcoinNetParams {
         p2shHeader = 5;
         acceptableAddressCodes = new int[] { addressHeader, p2shHeader };
         port = 8333;
-        packetMagic = 0xf9beb4d9L;
+        packetMagic = 0xe3e1f3e8;
         bip32HeaderPub = 0x0488B21E; //The 4 byte header that serializes in base58 to "xpub".
         bip32HeaderPriv = 0x0488ADE4; //The 4 byte header that serializes in base58 to "xprv"
 

--- a/core/src/main/java/org/bitcoincashj/params/TestNet2Params.java
+++ b/core/src/main/java/org/bitcoincashj/params/TestNet2Params.java
@@ -32,7 +32,7 @@ public class TestNet2Params extends AbstractBitcoinNetParams {
     public TestNet2Params() {
         super();
         id = ID_TESTNET;
-        packetMagic = 0xfabfb5daL;
+        packetMagic = 0xdab5bffa;
         port = 18333;
         addressHeader = 111;
         p2shHeader = 196;

--- a/core/src/main/java/org/bitcoincashj/params/TestNet3Params.java
+++ b/core/src/main/java/org/bitcoincashj/params/TestNet3Params.java
@@ -39,7 +39,7 @@ public class TestNet3Params extends AbstractBitcoinNetParams {
         super();
         id = ID_TESTNET;
         // Genesis hash is 000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943
-        packetMagic = 0x0b110907;
+        packetMagic = 0xf4e5f3f4;
         interval = INTERVAL;
         targetTimespan = TARGET_TIMESPAN;
         maxTarget = Utils.decodeCompactBits(0x1d00ffffL);

--- a/core/src/main/java/org/bitcoincashj/params/TestNet3Params.java
+++ b/core/src/main/java/org/bitcoincashj/params/TestNet3Params.java
@@ -58,10 +58,11 @@ public class TestNet3Params extends AbstractBitcoinNetParams {
         alertSigningKey = Utils.HEX.decode("04302390343f91cc401d56d68b123028bf52e5fca1939df127f63c6467cdf9c8e2c14b61104cf817d0b780da337893ecc4aaff1309e536162dabbdb45200ca2b0a");
 
         dnsSeeds = new String[] {
-                "testnet-seed.bitcoin.jonasschnelli.ch", // Jonas Schnelli
-                "testnet-seed.bluematt.me",              // Matt Corallo
-                "testnet-seed.bitcoin.petertodd.org",    // Peter Todd
-                "testnet-seed.bitcoin.schildbach.de",    // Andreas Schildbach
+                "testnet-seed.bitcoinabc.org",
+                "testnet-seed-abc.bitcoinforks.org",
+                "testnet-seed.bitprim.org",
+                "testnet-seed.deadalnix.me",
+                "testnet-seeder.criptolayer.net"
         };
         addrSeeds = null;
         bip32HeaderPub = 0x043587CF;


### PR DESCRIPTION
In order to work with Bitcoin Cash networks, you need to use the right "magic" numbers (see https://lists.linuxfoundation.org/pipermail/bitcoin-ml/2017-August/000072.html), and the right DNS seeds (and not those of Bitcoin).